### PR TITLE
Fix relative path load for translation.json file

### DIFF
--- a/mssqlpwner/utilities.py
+++ b/mssqlpwner/utilities.py
@@ -214,7 +214,7 @@ def print_state(state: dict) -> None:
     This function is responsible to print the last enumeration from the stored state.
     """
     LOG.info("Linkable servers:")
-    translation = json.load(open(os.path.join("./", "playbooks", "translation.json")))
+    translation = json.load(open(os.path.join(os.path.dirname(__file__), "playbooks", "translation.json")))
     for _, server_info in state["servers_info"].items():
         for translation_key, translation_value in translation.items():
             if translation_key in server_info.keys():


### PR DESCRIPTION
Fixes error
```
[*] Linkable servers:
Traceback (most recent call last):
  File "/usr/bin/mssqlpwner", line 8, in <module>
    sys.exit(console())
             ^^^^^^^^^
  File "/usr/lib/python3/dist-packages/mssqlpwner/cli.py", line 78, in console
    mssql_client.execute_module(options.chain_id, options.link_name, options)
  File "/usr/lib/python3/dist-packages/mssqlpwner/playbooks/playbooks.py", line 666, in execute_module
    utilities.print_state(self.state)
  File "/usr/lib/python3/dist-packages/mssqlpwner/utilities.py", line 217, in print_state
    translation = json.load(open(os.path.join("./", "playbooks", "translation.json")))
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: './playbooks/translation.json'

```