### PR TITLE
Fix pip install error: pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 ]
 
 [project.scripts]
-mssqlpwner = "mssqlpwner.console:run"
+mssqlpwner = "mssqlpwner.cli:console"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
```
└─$ mssqlpwner                                                                 
Traceback (most recent call last):
  File "/home/kali/.local/bin/mssqlpwner", line 5, in <module>
    from mssqlpwner import run
ImportError: cannot import name 'run' from 'mssqlpwner' (unknown location)
```

After making this change:
```
└─$ pipx install git+https://github.com/lefayjey/MSSqlPwner --force
Installing to existing venv 'mssqlpwner'
  installed package mssqlpwner 1.3.2, installed using Python 3.13.2
  These apps are now globally available
    - mssqlpwner
done! ✨  ✨
                                                                                                                                                                                                                                           
└─$ mssqlpwner        
usage: mssqlpwner [-h] [-port PORT] [-timeout TIMEOUT] [-db DB] [-windows-auth] [-no-state] [-debug] [-hashes LMHASH:NTHASH] [-no-pass] [-k] [-aesKey hex key] [-dc-ip ip address] [-link-name LINK_NAME]
                  [-max-link-depth MAX_LINK_DEPTH] [-max-impersonation-depth MAX_IMPERSONATION_DEPTH] [-chain-id CHAIN_ID] [-auto-yes]
                  target
                  {enumerate,set-chain,rev2self,get-rev2self-queries,get-chain-list,get-link-server-list,get-adsi-provider-list,set-link-server,exec,ntlm-relay,custom-asm,inject-custom-asm,direct-query,retrieve-password,interactive,brute} ...

TDS client implementation (SSL supported).
```