### PR TITLE
Fix IndexError when linked-server enumeration returns no rows

### DIFF
--- a/mssqlpwner/classes/operations.py
+++ b/mssqlpwner/classes/operations.py
@@ -312,6 +312,15 @@ class Operations(query_builder.QueryBuilder):
                 del self.state["servers_info"][chain_id]
                 return
 
+        if not enumeration_results["server_information"]["results"]:
+            reply = enumeration_results["server_information"].get("replay", "")
+            LOG.error(
+                f"Failed to retrieve server information from {chain_str}: "
+                f"query returned no rows ({reply or 'linked server may be inaccessible'})"
+            )
+            del self.state["servers_info"][chain_id]
+            return
+
         db_user = enumeration_results["server_information"]["results"][0]["db_user"]
         server_user = enumeration_results["server_information"]["results"][0][
             "server_user"


### PR DESCRIPTION
When a linked server has Data Access or RPC Out disabled, MSSQL returns the diagnostic ("Server 'X' is not configured for DATA ACCESS") as an info-level TDS token rather than an error token. The existing guard in retrieve_server_information only checks is_success, so an empty results list slipped through and crashed on results[0]["db_user"].

The fix is to add an empty-results check after the is_success loop. The fix also logs the underlying MSSQL reply so users see why the linked server returned no rows, then tear down the partial chain state the same way the is_success=False branch does, so enumeration continues with sibling chains instead of aborting the whole run.